### PR TITLE
feat: added analytics events

### DIFF
--- a/src/components/ProgramRecord/ProgramRecord.jsx
+++ b/src/components/ProgramRecord/ProgramRecord.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
@@ -35,10 +36,10 @@ function ProgramRecord({ isPublic }) {
     sendRecordFailureOrgs: [],
   });
 
-  const { programId } = useParams();
+  const { programUUID } = useParams();
 
   useEffect(() => {
-    getProgramDetails(programId, isPublic).then((data) => {
+    getProgramDetails(programUUID, isPublic).then((data) => {
       if (isEmpty(data)) {
         setHasNoData(true);
       } else {
@@ -50,9 +51,15 @@ function ProgramRecord({ isPublic }) {
       const errorMessage = (`Error: Could not fetch program record data for user: ${error.message}`);
       logError(errorMessage);
     });
-  }, [programId, isPublic]);
+  }, [programUUID, isPublic]);
 
   const toggleSendRecordModal = () => {
+    if (!sendRecord.sendRecordModalOpen) {
+      sendTrackEvent('edx.bi.credentials.program_record.send_started', {
+        category: 'records',
+        'program-uuid': programUUID,
+      });
+    }
     setSendRecord(prev => ({
       ...prev,
       sendRecordModalOpen: !prev.sendRecordModalOpen,
@@ -94,7 +101,7 @@ function ProgramRecord({ isPublic }) {
         toggleSendRecordModal={toggleSendRecordModal}
         renderBackButton={renderBackButton}
         username={recordDetails.record.learner.username}
-        programId={recordDetails.uuid}
+        programUUID={programUUID}
       />
       {sendRecord.sendRecordSuccessOrgs && sendRecord.sendRecordSuccessOrgs.map(org => (
         <ProgramRecordAlert
@@ -103,7 +110,7 @@ function ProgramRecord({ isPublic }) {
           onClose={updateSuccessAndFailureOrgs}
           creditPathway={org}
           setSendRecord={setSendRecord}
-          programId={programId}
+          programUUID={programUUID}
           username={recordDetails.record.learner.username}
           platform={recordDetails.record.platform_name}
         />
@@ -115,7 +122,7 @@ function ProgramRecord({ isPublic }) {
           onClose={updateSuccessAndFailureOrgs}
           creditPathway={org}
           setSendRecord={setSendRecord}
-          programId={programId}
+          programUUID={programUUID}
           username={recordDetails.record.learner.username}
           platform={recordDetails.record.platform_name}
         />
@@ -143,7 +150,7 @@ function ProgramRecord({ isPublic }) {
           isOpen={sendRecord.sendRecordModalOpen}
           toggleSendRecordModal={toggleSendRecordModal}
           creditPathways={recordDetails.record.pathways}
-          uuid={programId}
+          programUUID={programUUID}
           username={recordDetails.record.learner.username}
           setSendRecord={setSendRecord}
           platform={recordDetails.record.platform_name}

--- a/src/components/ProgramRecord/ProgramRecordActions.jsx
+++ b/src/components/ProgramRecord/ProgramRecordActions.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import PropTypes from 'prop-types';
 import {
@@ -15,7 +16,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { getProgramRecordUrl, getProgramRecordCsv } from './data/service';
 
 function ProgramRecordActions({
-  showSendRecordButton, isPublic, toggleSendRecordModal, renderBackButton, username, programId,
+  showSendRecordButton, isPublic, toggleSendRecordModal, renderBackButton, username, programUUID,
 }) {
   const [programRecordUrl, setProgramRecordUrl] = useState('');
   const [showCopyTooltip, setShowCopyTooltip] = useState(false);
@@ -75,7 +76,7 @@ function ProgramRecordActions({
     if (programRecordUrl) {
       navigator.clipboard.writeText(programRecordUrl);
     } else {
-      getProgramRecordUrl(programId, username)
+      getProgramRecordUrl(programUUID, username)
         .then(({ data }) => {
           setProgramRecordUrl(data.url);
           navigator.clipboard.writeText(data.url);
@@ -85,6 +86,10 @@ function ProgramRecordActions({
           throw new Error(error);
         });
     }
+    sendTrackEvent('edx.bi.credentials.program_record.share_url_copied', {
+      category: 'records',
+      'program-uuid': programUUID,
+    });
   };
 
   const handleCopyButtonClick = () => {
@@ -94,11 +99,11 @@ function ProgramRecordActions({
 
   const handleDownloadRecord = () => {
     setDownloadRecord('pending');
-    getProgramRecordCsv(programId)
+    getProgramRecordCsv(programUUID)
       .then(response => {
         if (response.status >= 200 && response.status < 300) {
           setDownloadRecord('complete');
-          window.location = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/shared/${programId}/csv`;
+          window.location = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/shared/${programUUID}/csv`;
         }
       })
       .catch((error) => {
@@ -242,7 +247,7 @@ ProgramRecordActions.propTypes = {
   toggleSendRecordModal: PropTypes.func.isRequired,
   renderBackButton: PropTypes.func.isRequired,
   username: PropTypes.string.isRequired,
-  programId: PropTypes.string.isRequired,
+  programUUID: PropTypes.string.isRequired,
 };
 
 export default ProgramRecordActions;

--- a/src/components/ProgramRecord/data/service.js
+++ b/src/components/ProgramRecord/data/service.js
@@ -1,8 +1,8 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-async function getProgramDetails(programId, isPublic) {
-  const url = `${getConfig().CREDENTIALS_BASE_URL}/records/api/v1/program_records/${programId}/?is_public=${isPublic}`;
+async function getProgramDetails(programUUID, isPublic) {
+  const url = `${getConfig().CREDENTIALS_BASE_URL}/records/api/v1/program_records/${programUUID}/?is_public=${isPublic}`;
   let data = {};
 
   try {
@@ -16,8 +16,8 @@ async function getProgramDetails(programId, isPublic) {
   return data;
 }
 
-export async function getProgramRecordUrl(programId, username) {
-  const url = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/${programId}/share`;
+export async function getProgramRecordUrl(programUUID, username) {
+  const url = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/${programUUID}/share`;
   try {
     const response = await getAuthenticatedHttpClient().post(url, { username });
     return response;
@@ -26,8 +26,8 @@ export async function getProgramRecordUrl(programId, username) {
   }
 }
 
-export async function getProgramRecordCsv(programId) {
-  const url = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/shared/${programId}/csv`;
+export async function getProgramRecordCsv(programUUID) {
+  const url = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/shared/${programUUID}/csv`;
   try {
     const response = await getAuthenticatedHttpClient().get(url, { withCredentials: true });
     return response;

--- a/src/components/ProgramRecord/test/DownloadCsv.test.jsx
+++ b/src/components/ProgramRecord/test/DownloadCsv.test.jsx
@@ -14,7 +14,7 @@ import programRecordFactory from './__factories__/programRecord.factory';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn().mockReturnValue({ programId: 'test-id' }),
+  useParams: jest.fn().mockReturnValue({ programUUID: 'test-id' }),
 }));
 
 let windowSpy;

--- a/src/components/ProgramRecord/test/ProgramRecord.test.jsx
+++ b/src/components/ProgramRecord/test/ProgramRecord.test.jsx
@@ -15,7 +15,7 @@ import programRecordUrlFactory from './__factories__/programRecordActions.factor
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn().mockReturnValue({ programId: 'test-id' }),
+  useParams: jest.fn().mockReturnValue({ programUUID: 'test-id' }),
 }));
 
 describe('program-record', () => {

--- a/src/components/ProgramRecordAlert/ProgramRecordAlert.jsx
+++ b/src/components/ProgramRecordAlert/ProgramRecordAlert.jsx
@@ -11,10 +11,10 @@ import { getConfig } from '@edx/frontend-platform';
 import sendRecords from '../ProgramRecordSendModal/data/service';
 
 const ProgramRecordAlert = ({
-  alertType, onClose, programId, username, setSendRecord, creditPathway, platform,
+  alertType, onClose, programUUID, username, setSendRecord, creditPathway, platform,
 }) => {
   const handleTryAgainSendRecord = () => {
-    sendRecords(programId, username, creditPathway.id)
+    sendRecords(programUUID, username, creditPathway.id)
       .then(response => {
         if (response.status >= 200 && response.status < 300) {
           setSendRecord(prev => ({
@@ -114,7 +114,7 @@ ProgramRecordAlert.propTypes = {
   onClose: PropTypes.func,
   creditPathway: PropTypes.shape().isRequired,
   setSendRecord: PropTypes.func,
-  programId: PropTypes.string,
+  programUUID: PropTypes.string,
   username: PropTypes.string,
   platform: PropTypes.string,
 };
@@ -123,7 +123,7 @@ ProgramRecordAlert.defaultProps = {
   alertType: '',
   onClose: () => {},
   setSendRecord: () => {},
-  programId: '',
+  programUUID: '',
   username: '',
   platform: '',
 };

--- a/src/components/ProgramRecordAlert/test/__factories__/programRecordAlert.factory.js
+++ b/src/components/ProgramRecordAlert/test/__factories__/programRecordAlert.factory.js
@@ -4,7 +4,7 @@ export default Factory.define('programAlertData')
   .attrs({
     alertType: '',
     onClose: () => {},
-    programId: '12345',
+    programUUID: '12345',
     username: 'edX',
     setSendRecord: () => {},
     creditPathway: {

--- a/src/components/ProgramRecordSendModal/SendLearnerRecordModal.jsx
+++ b/src/components/ProgramRecordSendModal/SendLearnerRecordModal.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+
 import PropTypes from 'prop-types';
 import {
   ModalDialog, Form, SelectableBox, ActionRow, Button,
@@ -10,7 +12,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import sendRecords from './data/service';
 
 function SendLearnerRecordModal({
-  isOpen, toggleSendRecordModal, creditPathways, uuid, username, setSendRecord, platform, programType,
+  isOpen, toggleSendRecordModal, creditPathways, programUUID, username, setSendRecord, platform, programType,
 }) {
   const [selectedPathways, setSelectedPathways] = useState([]);
 
@@ -22,7 +24,7 @@ function SendLearnerRecordModal({
       sendRecordFailureOrgs: [],
     };
 
-    await Promise.all(pathwaysToSendRecords.map(pathway => sendRecords(uuid, username, pathway.id)
+    await Promise.all(pathwaysToSendRecords.map(pathway => sendRecords(programUUID, username, pathway.id)
       .then(response => {
         if (response.status >= 200 && response.status < 300) {
           orgs.sendRecordSuccessOrgs.push(pathway);
@@ -40,6 +42,12 @@ function SendLearnerRecordModal({
       ...prev,
       ...orgs,
     }));
+
+    sendTrackEvent('edx.bi.credentials.program_record.send_finished', {
+      category: 'records',
+      'program-uuid': programUUID,
+      organizations: pathwaysToSendRecords,
+    });
 
     toggleSendRecordModal();
   };
@@ -153,7 +161,7 @@ SendLearnerRecordModal.propTypes = {
   toggleSendRecordModal: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   creditPathways: PropTypes.arrayOf(PropTypes.object).isRequired,
-  uuid: PropTypes.string.isRequired,
+  programUUID: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
   setSendRecord: PropTypes.func.isRequired,
   platform: PropTypes.string.isRequired,

--- a/src/components/ProgramRecordSendModal/data/service.js
+++ b/src/components/ProgramRecordSendModal/data/service.js
@@ -2,9 +2,9 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 import { logError } from '@edx/frontend-platform/logging';
 
-async function sendRecords(programId, username, orgId) {
+async function sendRecords(programUUID, username, orgId) {
   try {
-    const url = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/${programId}/send`;
+    const url = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/${programUUID}/send`;
     const response = await getAuthenticatedHttpClient().post(url, { username, pathway_id: orgId });
     return response;
   } catch (error) {

--- a/src/components/ProgramRecordSendModal/test/SendLearnerRecordModal.test.jsx
+++ b/src/components/ProgramRecordSendModal/test/SendLearnerRecordModal.test.jsx
@@ -6,6 +6,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { Factory } from 'rosie';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
+import * as analytics from '@edx/frontend-platform/analytics';
 import {
   render, screen, cleanup, fireEvent, act, initializeMockApp,
 } from '../../../setupTest';
@@ -14,8 +15,17 @@ import programRecordFactory from '../../ProgramRecord/test/__factories__/program
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn().mockReturnValue({ programId: 'test-id' }),
+  useParams: jest.fn().mockReturnValue({ programUUID: 'test-id' }),
 }));
+
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  configure: () => {},
+  sendTrackEvent: jest.fn(),
+}));
+
+beforeEach(() => {
+  analytics.sendTrackEvent.mockReset();
+});
 
 describe('program-record-alert', () => {
   beforeAll(async () => {
@@ -46,5 +56,11 @@ describe('program-record-alert', () => {
     // TODO: test for when the user clicks the send button inside the modal
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
     expect(screen.queryByText('Send Program Record to edX Credit Partner')).toBeNull();
+    expect(analytics.sendTrackEvent.mock.calls.length).toBe(1);
+    expect(analytics.sendTrackEvent.mock.calls[0][0]).toEqual('edx.bi.credentials.program_record.send_started');
+    expect(analytics.sendTrackEvent.mock.calls[0][1]).toEqual({
+      category: 'records',
+      'program-uuid': 'test-id',
+    });
   });
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -29,14 +29,14 @@ subscribe(APP_READY, () => {
               <ProgramRecordsList />
             </Route>
             <Route
-              path="/shared/:programId"
+              path="/shared/:programUUID"
             >
               <ProgramRecord
                 isPublic
               />
             </Route>
             <Route
-              path="/:programId"
+              path="/:programUUID"
             >
               <ProgramRecord
                 isPublic={false}


### PR DESCRIPTION
This PR adds three analytics events to the program details page. These events are carried over from the legacy frontend in [Credentials](https://github.com/openedx/credentials/tree/master/credentials/static/components).

The events added in this PR:
1. Opening the modal for sending program records - `edx.bi.credentials.program_record.send_started`
2. When the program records are sent for credit - `edx.bi.credentials.program_record.send_finished`
3. When the URL for the public record is copied - `edx.bi.credentials.program_record.share_url_copied`

_Minor change: modified the name of a prop from 'uuid' to 'programId' in an attempt to make things more clear_