### PR TITLE
feat: create/copy public record button

### DIFF
--- a/src/components/ProgramRecord/ProgramRecord.jsx
+++ b/src/components/ProgramRecord/ProgramRecord.jsx
@@ -102,6 +102,7 @@ function ProgramRecord({ isPublic }) {
         renderBackButton={renderBackButton}
         username={recordDetails.record.learner.username}
         programUUID={programUUID}
+        sharedRecordUUID={recordDetails.record.shared_program_record_uuid}
       />
       {sendRecord.sendRecordSuccessOrgs && sendRecord.sendRecordSuccessOrgs.map(org => (
         <ProgramRecordAlert

--- a/src/components/ProgramRecord/test/CopyToClipboard.test.jsx
+++ b/src/components/ProgramRecord/test/CopyToClipboard.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
+import { Factory } from 'rosie';
 import * as analytics from '@edx/frontend-platform/analytics';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
@@ -20,55 +21,82 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackEvent: jest.fn(),
 }));
 
-beforeEach(() => {
-  analytics.sendTrackEvent.mockReset();
-});
+describe('copy-to-clipboard', () => {
+  const originalClipboard = { ...global.navigator.clipboard };
 
-const originalClipboard = { ...global.navigator.clipboard };
-
-beforeAll(async () => {
-  await initializeMockApp();
-});
-
-beforeEach(() => {
-  const mockClipboard = {
-    writeText: jest.fn(
-      () => {},
-    ),
-    readText: jest.fn(
-      () => {},
-    ),
-  };
-  global.navigator.clipboard = mockClipboard;
-});
-
-afterEach(() => {
-  jest.resetAllMocks();
-  cleanup();
-  global.navigator.clipboard = originalClipboard;
-});
-
-it('copies a string to the clipboard', async () => {
-  await act(async () => {
-    const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-    axiosMock
-      .onGet(`${getConfig().CREDENTIALS_BASE_URL}/records/api/v1/program_records/test-id/?is_public=false`)
-      .reply(200, programRecordFactory.build());
-    axiosMock
-      .onPost()
-      .reply(200, programRecordUrlFactory.build());
-    render(<ProgramRecord isPublic={false} />);
+  beforeAll(async () => {
+    await initializeMockApp();
   });
 
-  const copyLink = screen.getByRole('button', { name: /copy program record link/i });
-  expect(copyLink).toBeTruthy();
-  fireEvent.click(copyLink);
-  expect(await screen.findByText('Link copied!')).toBeTruthy();
-  expect(navigator.clipboard.writeText).toBeCalledTimes(1);
-  expect(analytics.sendTrackEvent.mock.calls.length).toBe(1);
-  expect(analytics.sendTrackEvent.mock.calls[0][0]).toEqual('edx.bi.credentials.program_record.share_url_copied');
-  expect(analytics.sendTrackEvent.mock.calls[0][1]).toEqual({
-    category: 'records',
-    'program-uuid': 'test-id',
+  beforeEach(() => {
+    analytics.sendTrackEvent.mockReset();
+    const mockClipboard = {
+      writeText: jest.fn(
+        () => {},
+      ),
+      readText: jest.fn(
+        () => {},
+      ),
+    };
+    global.navigator.clipboard = mockClipboard;
+  });
+
+  afterEach(() => {
+    cleanup();
+    Factory.resetAll();
+    global.navigator.clipboard = originalClipboard;
+  });
+
+  it('copies a string to the clipboard', async () => {
+    await act(async () => {
+      const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+      axiosMock
+        .onGet(`${getConfig().CREDENTIALS_BASE_URL}/records/api/v1/program_records/test-id/?is_public=false`)
+        .reply(200, programRecordFactory.build());
+      axiosMock
+        .onPost()
+        .reply(200, programRecordUrlFactory.build());
+      render(<ProgramRecord isPublic={false} />);
+    });
+    const createButton = screen.getByRole('button', { name: /create program record link/i });
+    expect(createButton).toBeTruthy();
+    fireEvent.click(createButton);
+    expect(await screen.findByText('Link copied!')).toBeTruthy();
+    expect(navigator.clipboard.writeText).toBeCalledTimes(1);
+    expect(analytics.sendTrackEvent.mock.calls.length).toBe(2);
+    expect(analytics.sendTrackEvent.mock.calls[0][0]).toEqual('edx.bi.credentials.program_record.share_url_copied');
+    expect(analytics.sendTrackEvent.mock.calls[0][1]).toEqual({
+      category: 'records',
+      'program-uuid': 'test-id',
+    });
+    expect(analytics.sendTrackEvent.mock.calls[1][0]).toEqual('edx.bi.credentials.program_record.share_started');
+    expect(analytics.sendTrackEvent.mock.calls[1][1]).toEqual({
+      category: 'records',
+      'program-uuid': 'test-id',
+    });
+  });
+
+  it('renders a "Copy program record link" button when a public link exists', async () => {
+    const responseMock = programRecordFactory.build();
+    await act(async () => {
+      responseMock.record.shared_program_record_uuid = 'test-public-id';
+      const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+      axiosMock
+        .onGet(`${getConfig().CREDENTIALS_BASE_URL}/records/api/v1/program_records/test-id/?is_public=false`)
+        .reply(200, responseMock);
+      axiosMock
+        .onPost()
+        .reply(200, programRecordUrlFactory.build());
+      render(<ProgramRecord isPublic={false} />);
+    });
+    const copyButton = screen.getByRole('button', { name: /copy program record link/i });
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton);
+    expect(analytics.sendTrackEvent.mock.calls.length).toBe(1);
+    expect(analytics.sendTrackEvent.mock.calls[0][0]).toEqual('edx.bi.credentials.program_record.share_url_copied');
+    expect(analytics.sendTrackEvent.mock.calls[0][1]).toEqual({
+      category: 'records',
+      'program-uuid': 'test-id',
+    });
   });
 });

--- a/src/components/ProgramRecord/test/ProgramRecord.test.jsx
+++ b/src/components/ProgramRecord/test/ProgramRecord.test.jsx
@@ -66,7 +66,7 @@ describe('program-record', () => {
         .reply(200, programRecordUrlFactory.build());
       render(<ProgramRecord isPublic={false} />);
     });
-    expect(screen.queryByRole('button', { name: 'Send program record ' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Send program record' })).toBeNull();
   });
 
   it('renders alert on successful request with no data', async () => {

--- a/src/components/ProgramRecord/test/__factories__/programRecord.factory.js
+++ b/src/components/ProgramRecord/test/__factories__/programRecord.factory.js
@@ -60,6 +60,7 @@ export default Factory.define('program_record_details')
         pathway_type: 'credit',
       },
     ],
+    shared_program_record_uuid: '',
   })
   .attr('is_public', 'false')
   .attr('uuid', '82d38639ccc340db8be5f0f259500dde')


### PR DESCRIPTION
This PR addresses a change from the MFE conversion. In this conversion, we've decided to remove the modal that opens up when a user wants to copy a public link. In its place is a button that conditionally renders based on the existence of a public record. In order to accommodate this change, we had to address a few things [outlined here](https://2u-internal.atlassian.net/jira/software/c/projects/APER/boards/585?modal=detail&selectedIssue=APER-1947), namely:

- What information is rendered to the page for each instance
- How do we re-implement the analytics event that would fire when the modal opened up

The initial REST API call that retrieves program details also contains a field for the `shared_program_record_uuid` which will be populated if a public record already exists. In this instance, the uuid is used to construct a public link.

If one does not exist, users will be prompted to "Create" a public record link.
![Screen Shot 2022-09-08 at 10 27 13 AM](https://user-images.githubusercontent.com/92897870/189148432-98ded542-4110-4e8d-a900-2b0269cedb99.png)
Otherwise, they can simply copy the existing link:
![Screen Shot 2022-09-08 at 10 26 56 AM](https://user-images.githubusercontent.com/92897870/189148334-eac39609-418d-479d-892d-4f6896b64368.png)

If the `shared_program_record_uuid` field is empty, then a request will be made to create the public record when the user clicks the button. This is also when the aforementioned analytics event is set to fire.



